### PR TITLE
Pin ISAR version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY . .
 RUN pip install .
 
-FROM ghcr.io/equinor/isar:latest
+FROM ghcr.io/equinor/isar:v1.12.5
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
We have had bugs where we did not use the ISAR version we thought we were, this would solve that and make it clear what ISAR version we are expecting isar-robot to run with.