### PR TITLE
Pin pip version temporarily

### DIFF
--- a/.github/workflows/compile_requirements.yml
+++ b/.github/workflows/compile_requirements.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install pip-tools
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install pip==25.2
           pip install pip-tools
 
       - name: Upgrade dependencies and compile requirements file


### PR DESCRIPTION
At the moment pip 25.3 is incompatible with pip-tools 7.5.1.
Look at this [issue](https://github.com/jazzband/pip-tools/issues/2252) for more information. 