### PR TITLE
Add SHOULD_START_AT_HOME setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ isar = { path = "../isar", editable = true }
 repository = "https://github.com/equinor/isar-robot.git"
 
 [project.optional-dependencies]
-dev = ["black", "mypy", "pytest", "ruff"]
+dev = ["black", "mypy", "pytest", "pytest-mock", "ruff"]
 
 [tool.setuptools_scm]
 version_file = "src/isar_robot/version.py"

--- a/src/isar_robot/config/settings.py
+++ b/src/isar_robot/config/settings.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     MISSION_SIMULATION_TASK_DURATION: float = Field(default=5.0)
     INITIATE_MISSION_DURATION_IN_SECONDS: float = Field(default=0.1)
     SHOULD_HAVE_RANDOM_BATTERY_LEVEL: bool = Field(default=False)
+    SHOULD_START_AT_HOME: bool = Field(default=False)
     ROBOT_POSE_PUBLISH_INTERVAL: float = Field(default=1)
     ROBOT_BATTERY_PUBLISH_INTERVAL: float = Field(default=2)
     ROBOT_OBSTACLE_STATUS_PUBLISH_INTERVAL: float = Field(default=10)

--- a/src/isar_robot/robotinterface.py
+++ b/src/isar_robot/robotinterface.py
@@ -41,7 +41,7 @@ class Robot(RobotInterface):
 
         self.telemetry = telemetry.Telemetry()
         self.last_task_completion_time: datetime = datetime.now(timezone.utc)
-        self.robot_is_home: bool = False
+        self.robot_is_home: bool = settings.SHOULD_START_AT_HOME
         self.mission_simulation: Optional[MissionSimulation] = None
 
     def initiate_mission(self, mission: Mission) -> None:

--- a/tests/interfaces/test_robotinterface.py
+++ b/tests/interfaces/test_robotinterface.py
@@ -1,5 +1,7 @@
+from robot_interface.models.mission.status import RobotStatus
 from robot_interface.test_robot_interface import interface_test
 
+from isar_robot.config.settings import settings
 from isar_robot.robotinterface import Robot
 
 
@@ -47,3 +49,14 @@ def test_pressure_telemetry():
         isar_id="test_id", robot_name="test_robot"
     )
     assert pressure_telemetry is not None
+
+
+def test_initial_robot_status_defaults_to_available():
+    robot = Robot(robot_name="Robot", isar_id="00000000-0000-0000-0000-000000000000")
+    assert robot.robot_status() == RobotStatus.Available
+
+
+def test_initial_robot_status_is_home_when_should_start_at_home(mocker):
+    mocker.patch.object(settings, "SHOULD_START_AT_HOME", True)
+    robot = Robot(robot_name="Robot", isar_id="00000000-0000-0000-0000-000000000000")
+    assert robot.robot_status() == RobotStatus.Home

--- a/uv.lock
+++ b/uv.lock
@@ -517,6 +517,7 @@ dev = [
     { name = "black" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -527,6 +528,7 @@ requires-dist = [
     { name = "isar", specifier = ">=2.1.2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-mock", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
@@ -1040,6 +1042,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new boolean setting **`SHOULD_START_AT_HOME`** (env var `ROBOT_SHOULD_START_AT_HOME`, default `False`) that, when enabled, causes the simulated robot to report `RobotStatus.Home` on startup instead of `RobotStatus.Available`. With this enabled, ISAR's state machine transitions directly into the `Home` state on boot and skips the bootstrap return-home cycle.

## Why

Integration tests in [`equinor/armada`](https://github.com/equinor/armada) currently race against the bootstrap return-home cycle. In `test_multiple_robots_parallel_missions`, robots configured to fail return-home reach `InterventionNeeded` during boot — before the test gets a chance to schedule its echo mission — leaving the queued mission run permanently stuck. (Concrete failure: [equinor/flotilla actions run #25423080464](https://github.com/equinor/flotilla/actions/runs/25423080464/job/74569703992).)

Letting the test opt the simulated robots into starting at home eliminates this race deterministically: the test can schedule its echo mission, the mission runs to completion, and the configured return-home failure only fires *after* the mission, exactly matching the test's intent.

## Changes

- `src/isar_robot/config/settings.py`: new `SHOULD_START_AT_HOME` field (default `False`).
- `src/isar_robot/robotinterface.py`: initialize `self.robot_is_home` from the new setting (was hard-coded `False`). Existing `robot_status()` logic already returns `RobotStatus.Home` when this is true, so no other changes were needed.
- `tests/interfaces/test_robotinterface.py`: two new tests covering the default (`Available`) and the opt-in (`Home`) behavior.

## Compatibility

Default is `False`, so existing behavior is unchanged for all current users (including production deployments and other integration tests). This is a purely additive, opt-in change.

## Follow-up

A subsequent PR in [`equinor/armada`](https://github.com/equinor/armada) will set `ROBOT_SHOULD_START_AT_HOME=true` for the multi-robot parallel test fixture, blocked on this PR being merged and a new `isar-robot` image being published.

## Test plan

- `pytest tests/` — all 15 tests pass (13 existing + 2 new).
- `black --check`, `ruff check` — clean.