### PR TITLE
Add mock support for TakeAcousticMeasurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["alitra", "isar>=2.1.3"]
+dependencies = ["alitra", "isar>=2.1.4"]
 dynamic = ["version"]
 
 [tool.uv.sources]

--- a/src/isar_robot/config/settings.env
+++ b/src/isar_robot/config/settings.env
@@ -1,2 +1,2 @@
-CAPABILITIES = '["take_thermal_image", "take_image", "take_video", "take_thermal_video", "record_audio", "take_co2_measurement"]'
+CAPABILITIES = '["take_thermal_image", "take_image", "take_video", "take_thermal_video", "record_audio", "take_co2_measurement", "take_acoustic_measurement"]'
 ROBOT_MODEL = Robot

--- a/src/isar_robot/inspections.py
+++ b/src/isar_robot/inspections.py
@@ -8,6 +8,8 @@ from robot_interface.models.exceptions.robot_exceptions import (
     RobotRetrieveInspectionException,
 )
 from robot_interface.models.inspection.inspection import (
+    AcousticMeasurement,
+    AcousticMeasurementMetadata,
     Audio,
     AudioMetadata,
     CO2Measurement,
@@ -24,6 +26,7 @@ from robot_interface.models.inspection.inspection import (
 from robot_interface.models.mission.task import (
     InspectionTask,
     RecordAudio,
+    TakeAcousticMeasurement,
     TakeCO2Measurement,
     TakeImage,
     TakeThermalImage,
@@ -171,6 +174,34 @@ def create_co2_measurement(task: TakeCO2Measurement, telemetry: Telemetry):
         value=random.normalvariate(0.043, 0.005),
         unit="% v/v",
     )
+
+
+def create_acoustic_measurement(
+    task: TakeAcousticMeasurement, telemetry: Telemetry
+) -> AcousticMeasurement:
+    now: datetime = datetime.now(timezone.utc)
+    metadata: AcousticMeasurementMetadata = AcousticMeasurementMetadata(
+        start_time=now,
+        robot_pose=telemetry.get_pose(),
+        target_position=_get_target_position(task, telemetry),
+        file_type="mp4",
+        duration=11.0,
+        snr_value=0.0,
+        leak_rate=0.0,
+        leak_rate_unit="l/min",
+        sound_pressure_level_at_sensor_db=40.0,
+        sound_pressure_level_at_source_db=45.0,
+        distance_to_source=2.0,
+        result="RI_NO_ANOMALY",
+        frequency_from=task.frequency_from,
+        frequency_to=task.frequency_to,
+    )
+    metadata.tag_id = task.tag_id
+    metadata.inspection_description = task.inspection_description
+
+    data = _read_data_from_file(example_video)
+
+    return AcousticMeasurement(metadata=metadata, id=task.inspection_id, data=data)
 
 
 def _read_data_from_file(filename: Path) -> bytes:

--- a/src/isar_robot/robotinterface.py
+++ b/src/isar_robot/robotinterface.py
@@ -18,6 +18,7 @@ from robot_interface.models.mission.status import MissionStatus, RobotStatus, Ta
 from robot_interface.models.mission.task import (
     InspectionTask,
     RecordAudio,
+    TakeAcousticMeasurement,
     TakeCO2Measurement,
     TakeImage,
     TakeThermalImage,
@@ -106,6 +107,8 @@ class Robot(RobotInterface):
             return inspections.create_thermal_video(task, self.telemetry)
         elif type(task) is TakeCO2Measurement:
             return inspections.create_co2_measurement(task, self.telemetry)
+        elif type(task) is TakeAcousticMeasurement:
+            return inspections.create_acoustic_measurement(task, self.telemetry)
         elif type(task) is RecordAudio:
             return inspections.create_audio(task, self.telemetry)
         else:

--- a/tests/test_inspections.py
+++ b/tests/test_inspections.py
@@ -1,6 +1,8 @@
 from alitra import Frame, Position, Pose, Orientation
 from robot_interface.models.mission.task import (
+    AcousticDetectionType,
     RecordAudio,
+    TakeAcousticMeasurement,
     TakeImage,
     TakeThermalImage,
     TakeThermalVideo,
@@ -57,3 +59,19 @@ def test_create_audio() -> None:
 
     assert inspection_recording.metadata.file_type == "wav"
     assert inspection_recording.metadata.duration == 10
+
+
+def test_create_acoustic_measurement() -> None:
+    task_actions = TakeAcousticMeasurement(
+        target=target,
+        robot_pose=robot_pose,
+        frequency_from=35000,
+        frequency_to=40000,
+        snr_value_threshold=10,
+        detection_type=AcousticDetectionType.leak,
+    )
+
+    inspection = inspections.create_acoustic_measurement(task_actions, telemetryModule)
+
+    assert inspection.metadata.file_type == "mp4"
+    assert inspection.metadata.frequency_from == 35000

--- a/uv.lock
+++ b/uv.lock
@@ -511,7 +511,7 @@ wheels = [
 
 [[package]]
 name = "isar"
-version = "2.1.3"
+version = "2.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alitra" },
@@ -543,9 +543,9 @@ dependencies = [
     { name = "transitions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/82/7d911ea003977cdffdf450daacba7c970a843e2482ed20869764a8aeeb18/isar-2.1.3.tar.gz", hash = "sha256:fc78ed04802805df2795602c006e480c66a6e9bd831cd73cd8b1f69eba2fb395", size = 210440, upload-time = "2026-05-19T09:09:50.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/4c/5cb475ae7f624286d2f5174eb72799a3adce1f0fdf68de04737c0e28805c/isar-2.1.4.tar.gz", hash = "sha256:39c56f17c1bc424914337c09a77ab94a1dde6148fd2df733085054b6c6749835", size = 212052, upload-time = "2026-06-08T07:35:55.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/04/83d8b8fcf4052f423655cd9eb2d5bf35b830c151d9d67a0a5381fb700e00/isar-2.1.3-py3-none-any.whl", hash = "sha256:06e27e003c7c1855e83485afbc8e5ee8d1e95f7ee6071deeab8cd667e3ee978c", size = 120822, upload-time = "2026-05-19T09:09:48.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/32/de5b43322191e94ea59bf6a3a3a4f8a31157a5e8b84ed1486bc4520355b7/isar-2.1.4-py3-none-any.whl", hash = "sha256:56909abb5e97075ab106e89eba69b70fcad017b18fcb9ad0ca82117de738e649", size = 121930, upload-time = "2026-06-08T07:35:54.03Z" },
 ]
 
 [[package]]
@@ -569,7 +569,7 @@ dev = [
 requires-dist = [
     { name = "alitra" },
     { name = "black", marker = "extra == 'dev'" },
-    { name = "isar", specifier = ">=2.1.3" },
+    { name = "isar", specifier = ">=2.1.4" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },


### PR DESCRIPTION
Adds mock support for `TakeAcousticMeasurement` so the acoustic stack ([isar#1137](https://github.com/equinor/isar/pull/1137), [flotilla#2741](https://github.com/equinor/flotilla/pull/2741), [isar-anymal#6](https://github.com/equinor/isar-anymal/pull/6)) can be exercised end-to-end without a physical robot.

- `create_acoustic_measurement` returns a fixed `RI_NO_ANOMALY` payload with `example_video.mp4` as the blob.
- One new dispatch branch in `Robot.get_inspection`.
- Bump `isar>=2.1.4`. Lockfile refresh deferred until isar 2.1.4 ships, so CI here will be red until then.